### PR TITLE
Fix typo in inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ would now look like:
   with:
     user: __token__
     password: ${{ secrets.pypi_password }}
-    packages-dir: custom-dir/
+    packages_dir: custom-dir/
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   repository_url:
     description: The repository URL to use
     required: false
-  packages-dir:
+  packages_dir:
     description: The target directory for distribution
     required: false
     default: dist
@@ -26,4 +26,4 @@ runs:
   - ${{ inputs.user }}
   - ${{ inputs.password }}
   - ${{ inputs.repository_url }}
-  - ${{ inputs.packages-dir }}
+  - ${{ inputs.packages_dir }}


### PR DESCRIPTION
We need to use underscores rather than dashes for inputs, otherwise we end up with a mal-formed docker run command. Example failures:

```
Run pypa/gh-action-pypi-publish@master
  with:
    user: __token__
    password: ***
    packages-dir: dist
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.0/x64
/usr/bin/docker run --name [...] -e INPUT_PACKAGES-DIR [...]

/app/twine-upload.sh: line 22: INPUT_PACKAGES_DIR: unbound variable
##[error]Docker run failed with exit code 1
```